### PR TITLE
interactive legend - alpha_unsel and alpha_over

### DIFF
--- a/examples/interactive_legend.py
+++ b/examples/interactive_legend.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import mpld3
 from mpld3 import plugins
+np.random.seed(9615)
 
 # generate df
 N = 100
@@ -29,8 +30,10 @@ for key, val in df.iteritems():
                     color=l.get_color(), alpha=.4)
 
 # define interactive legend
+
 handles, labels = ax.get_legend_handles_labels() # return lines and labels
-interactive_legend = plugins.InteractiveLegendPlugin(zip(handles, ax.collections),
+interactive_legend = plugins.InteractiveLegendPlugin(zip(handles,
+                                                         ax.collections),
                                                      labels,
                                                      alpha_unsel=0.5,
                                                      alpha_over=1.5, 

--- a/examples/interactive_legend.py
+++ b/examples/interactive_legend.py
@@ -1,0 +1,44 @@
+"""
+Interactive legend plugin
+=========================
+This is a demonstration of how to add an interactive legend to data plots.
+The Plugin is defined within mpld3. The user provides how select/unselect
+and legend overlay 
+will affect the alpha parameter of associated objects.
+You can also control how to initialize the graph: all selected or unselected.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import mpld3
+from mpld3 import plugins
+
+# generate df
+N = 100
+df = pd.DataFrame((.1 * (np.random.random((N, 5)) - .5)).cumsum(0),
+                  columns=['a', 'b', 'c', 'd', 'e'],)
+
+# plot line + confidence interval
+fig, ax = plt.subplots()
+ax.grid(True, alpha=0.3)
+
+for key, val in df.iteritems():
+    l, = ax.plot(val.index, val.values, label=key)
+    ax.fill_between(val.index,
+                    val.values * .5, val.values * 1.5,
+                    color=l.get_color(), alpha=.4)
+
+# define interactive legend
+handles, labels = ax.get_legend_handles_labels() # return lines and labels
+interactive_legend = plugins.InteractiveLegendPlugin(zip(handles, ax.collections),
+                                                     labels,
+                                                     alpha_unsel=0.5,
+                                                     alpha_over=1.5, 
+                                                     start_visible=True)
+plugins.connect(fig, interactive_legend)
+
+ax.set_xlabel('x')
+ax.set_ylabel('y')
+ax.set_title('Interactive legend', size=20)
+
+mpld3.show()

--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -454,6 +454,8 @@ class InteractiveLegendPlugin(PluginBase):
         the alpha value to multiply the plot_element(s) associated alpha
         with the legend item when the legend item is overlaid.
         Default is 1 (no effect), 1.5 works nicely !
+    start_visible : boolean, optional
+        defines if objects should start selected on not.
     Examples
     --------
     >>> import matplotlib.pyplot as plt
@@ -469,7 +471,8 @@ class InteractiveLegendPlugin(PluginBase):
     >>> interactive_legend = plugins.InteractiveLegendPlugin(line_collections,
     ...                                                      labels,
     ...                                                      alpha_unsel=0.2,
-    ...                                                      alpha_over=1.5)
+    ...                                                      alpha_over=1.5,
+    ...                                                      start_visible=True)
     >>> plugins.connect(fig, interactive_legend)
     >>> fig_to_html(fig)
     """
@@ -532,15 +535,15 @@ class InteractiveLegendPlugin(PluginBase):
         legend.selectAll("rect")
                 .data(legendItems)
                 .enter().append("rect")
-                .attr("height",10)
+                .attr("height", 10)
                 .attr("width", 25)
-                .attr("x",ax.width+10+ax.position[0])
+                .attr("x", ax.width + ax.position[0] + 25)
                 .attr("y",function(d,i) {
-                            return ax.position[1]+ i * 25 - 10;})
+                           return ax.position[1] + i * 25 + 10;})
                 .attr("stroke", get_color)
                 .attr("class", "legend-box")
                 .style("fill", function(d, i) {
-                            return d.visible ? get_color(d) : "white";})
+                           return d.visible ? get_color(d) : "white";})
                 .on("click", click).on('mouseover', over).on('mouseout', out);
 
         // add the labels
@@ -548,9 +551,9 @@ class InteractiveLegendPlugin(PluginBase):
               .data(legendItems)
               .enter().append("text")
               .attr("x", function (d) {
-                            return ax.width+10+ax.position[0] + 40;})
+                           return ax.width + ax.position[0] + 25 + 40;})
               .attr("y", function(d,i) {
-                            return ax.position[1]+ i * 25;})
+                           return ax.position[1] + i * 25 + 10 + 10 - 1;})
               .text(function(d) { return d.label });
 
 

--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -513,6 +513,7 @@ class InteractiveLegendPlugin(PluginBase):
             obj.mpld3_elements = mpld3_elements;
             obj.visible = start_visible; // should become be setable from python side
             legendItems.push(obj);
+            set_alphas(obj, false);
         }
 
         // determine the axes with which this legend is associated
@@ -544,13 +545,14 @@ class InteractiveLegendPlugin(PluginBase):
 
         // add the labels
         legend.selectAll("text")
-                .data(legendItems)
-            .enter().append("text")
+              .data(legendItems)
+              .enter().append("text")
               .attr("x", function (d) {
                             return ax.width+10+ax.position[0] + 40;})
               .attr("y", function(d,i) {
                             return ax.position[1]+ i * 25;})
               .text(function(d) { return d.label });
+
 
         // specify the action on click
         function click(d,i){
@@ -559,85 +561,48 @@ class InteractiveLegendPlugin(PluginBase):
               .style("fill",function(d, i) {
                 return d.visible ? get_color(d) : "white";
               })
+            set_alphas(d, false);
 
+        };
+
+        // specify the action on legend overlay 
+        function over(d,i){
+             set_alphas(d, true);
+        };
+
+        // specify the action on legend overlay 
+        function out(d,i){
+             set_alphas(d, false);
+        };
+
+        // helper function for setting alphas
+        function set_alphas(d, is_over){
             for(var i=0; i<d.mpld3_elements.length; i++){
                 var type = d.mpld3_elements[i].constructor.name;
 
                 if(type =="mpld3_Line"){
                     var current_alpha = d.mpld3_elements[i].props.alpha;
-                    var current_alpha_unsel= current_alpha * alpha_unsel;
+                    var current_alpha_unsel = current_alpha * alpha_unsel;
+                    var current_alpha_over = current_alpha * alpha_over;
                     d3.select(d.mpld3_elements[i].path[0][0])
-                        .style("stroke-opacity",
-                                d.visible ? current_alpha : current_alpha_unsel);
+                        .style("stroke-opacity", is_over ? current_alpha_over :
+                                                (d.visible ? current_alpha : current_alpha_unsel))
+                        .style("stroke-width", is_over ? 
+                                alpha_over * d.mpld3_elements[i].props.edgewidth : d.mpld3_elements[i].props.edgewidth);
                 } else if((type=="mpld3_PathCollection")||
                          (type=="mpld3_Markers")){
                     var current_alpha = d.mpld3_elements[i].props.alphas[0];
                     var current_alpha_unsel = current_alpha * alpha_unsel;
+                    var current_alpha_over = current_alpha * alpha_over;
                     d3.selectAll(d.mpld3_elements[i].pathsobj[0])
-                        .style("stroke-opacity",
-                                d.visible ? current_alpha : current_alpha_unsel)
-                        .style("fill-opacity",
-                                d.visible ? current_alpha : current_alpha_unsel);
+                        .style("stroke-opacity", is_over ? current_alpha_over :
+                                                (d.visible ? current_alpha : current_alpha_unsel))
+                        .style("fill-opacity", is_over ? current_alpha_over :
+                                                (d.visible ? current_alpha : current_alpha_unsel));
                 } else{
                     console.log(type + " not yet supported");
                 }
             }
-        };
-
-       // specify the action on legend overlay 
-       function over(d,i){
-
-                for(var i=0; i<d.mpld3_elements.length; i++){
-                    var type = d.mpld3_elements[i].constructor.name;
-
-                    if(type =="mpld3_Line"){
-                        var current_alpha = d.mpld3_elements[i].props.alpha;
-                        var current_alpha_over= current_alpha * alpha_over;
-                        d3.select(d.mpld3_elements[i].path[0][0])
-                            .style("stroke-opacity",
-                                    d.visible ? current_alpha_over : current_alpha)
-                        .style("stroke-width", alpha_over * d.mpld3_elements[i].props.edgewidth);
-                    } else if((type=="mpld3_PathCollection")||
-                             (type=="mpld3_Markers")){
-                        var current_alpha = d.mpld3_elements[i].props.alphas[0];
-                        var current_alpha_over = current_alpha * alpha_over;
-                        d3.selectAll(d.mpld3_elements[i].pathsobj[0])
-                            .style("stroke-opacity",
-                                    d.visible ? current_alpha_over : current_alpha)
-                            .style("fill-opacity",
-                                    d.visible ? current_alpha_over : current_alpha);
-                    } else{
-                        console.log(type + " not yet supported");
-                    }
-                }
-        };
-
-       // specify the action on legend overlay 
-       function out(d,i){
-
-                for(var i=0; i<d.mpld3_elements.length; i++){
-                    var type = d.mpld3_elements[i].constructor.name;
-
-                    if(type =="mpld3_Line"){
-                        var current_alpha = d.mpld3_elements[i].props.alpha;
-                        var current_alpha_unsel = current_alpha * alpha_unsel;
-                        d3.select(d.mpld3_elements[i].path[0][0])
-                            .style("stroke-opacity",
-                                    d.visible ? current_alpha : current_alpha_unsel)
-                        .style("stroke-width", d.mpld3_elements[i].props.edgewidth);
-                    } else if((type=="mpld3_PathCollection")||
-                             (type=="mpld3_Markers")){
-                        var current_alpha = d.mpld3_elements[i].props.alphas[0];
-                        var current_alpha_over = current_alpha * alpha_unsel;
-                        d3.selectAll(d.mpld3_elements[i].pathsobj[0])
-                            .style("stroke-opacity",
-                                    d.visible ? current_alpha : current_alpha_unsel)
-                            .style("fill-opacity",
-                                    d.visible ? current_alpha : current_alpha_unsel);
-                    } else{
-                        console.log(type + " not yet supported");
-                    }
-                }
         };
 
 

--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -449,6 +449,10 @@ class InteractiveLegendPlugin(PluginBase):
         the alpha value to multiply the plot_element(s) associated alpha
         with the legend item when the legend item is unselected.
         Default is 0.2
+    alpha_over : float, optional
+        the alpha value to multiply the plot_element(s) associated alpha
+        with the legend item when the legend item is overlaid.
+        Default is 1 (no effect), 1.5 works nicely !
     Examples
     --------
     >>> import matplotlib.pyplot as plt
@@ -460,10 +464,11 @@ class InteractiveLegendPlugin(PluginBase):
     >>> y = y.cumsum(1)
     >>> fig, ax = plt.subplots()
     >>> labels = ["a", "b", "c", "d", "e"]
-    >>> line_collections = ax.plot(x, y.T, lw=4, alpha=0.1)
+    >>> line_collections = ax.plot(x, y.T, lw=4, alpha=0.6)
     >>> interactive_legend = plugins.InteractiveLegendPlugin(line_collections,
     ...                                                      labels,
-    ...                                                      alpha_unsel=0.1)
+    ...                                                      alpha_unsel=0.2,
+    ...                                                      alpha_over=1.5)
     >>> plugins.connect(fig, interactive_legend)
     >>> fig_to_html(fig)
     """

--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -474,13 +474,15 @@ class InteractiveLegendPlugin(PluginBase):
     InteractiveLegend.prototype.constructor = InteractiveLegend;
     InteractiveLegend.prototype.requiredProps = ["element_ids", "labels"];
     InteractiveLegend.prototype.defaultProps = {"ax":null,
-                                                "alpha_unsel":1.0,}
+                                                "alpha_unsel":1.0,
+                                                "start_visible":true}
     function InteractiveLegend(fig, props){
         mpld3.Plugin.call(this, fig, props);
     };
 
     InteractiveLegend.prototype.draw = function(){
         var alpha_unsel = this.props.alpha_unsel;
+        var start_visible = this.props.start_visible;
 
         var legendItems = new Array();
         for(var i=0; i<this.props.labels.length; i++){
@@ -501,7 +503,7 @@ class InteractiveLegendPlugin(PluginBase):
             }
 
             obj.mpld3_elements = mpld3_elements;
-            obj.visible = true; // should become be setable from python side
+            obj.visible = start_visible; // should become be setable from python side
             legendItems.push(obj);
         }
 
@@ -598,7 +600,7 @@ class InteractiveLegendPlugin(PluginBase):
     """
 
     def __init__(self, plot_elements, labels, ax=None,
-                 alpha_unsel=0.2):
+                 alpha_unsel=0.2, start_visible=True):
 
         self.ax = ax
 
@@ -611,7 +613,8 @@ class InteractiveLegendPlugin(PluginBase):
                       "element_ids": mpld3_element_ids,
                       "labels": labels,
                       "ax": ax,
-                      "alpha_unsel": alpha_unsel}
+                      "alpha_unsel": alpha_unsel,
+                      "start_visible": start_visible}
 
     def _determine_mpld3ids(self, plot_elements):
         """

--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -323,8 +323,9 @@ class PointHTMLTooltip(PluginBase):
 
        obj.elements()
            .on("mouseover", function(d, i){
+			      if ($(obj.elements()[0][0]).css( "fill-opacity" ) > 0 || $(obj.elements()[0][0]).css( "stroke-opacity" ) > 0) {
                               tooltip.html(labels[i])
-                                     .style("visibility", "visible");})
+                                     .style("visibility", "visible");} })
            .on("mousemove", function(d, i){
                   tooltip
                     .style("top", d3.event.pageY + this.props.voffset + "px")


### PR DESCRIPTION
I wanted to report a bug for the `InteractiveLegend` on a quite common use case: line + fill_between (used as a confidence interval), but i decided to spend some time to try to fix it... 
And as a result of this time, here is some ideas about the `InteractiveLegend` plugin (which is an amazing feature, thanks a lot !).

The 2 original parameters of the plugin `alpha_sel` and `alpha_unsel` are applied to all objects associated with the legend items and so after a select / unselect both line and associated confidence interval are using the same alpha.
In this proposal, i only define `alpha_unsel` which is used as a ratio of the alpha defined in matplotlib. It allows to still distinguish the line from the confidence interval "on click" and switch back to the alpha defined in the original matplotlib figure.

A demo might be useful: http://nbviewer.ipython.org/gist/fdeheeger/745c349477dc72b12be1 

Because i was happy with the result (and because it was friday afternoon), i also played with mouseover on the legend. A second parameter `alpha_over` is again a ratio of the original alpha used to highlight objects. (i also use that parameter to multiply the line width.. just a try)

Different configurations are useful:
  - `alpha_unsel` fixed at 0 make objects invisible when unselected
  - `alpha_over` fixed at 1 disable the mouseover

Another idea (not implemented.. i am slow with javascript !): on large legend i thought that it might be nice not to need to click to sel/unsel objects and only use the mouse over to add or remove lines from the figure.

It is not a polished PR but i wanted to share it with you ! Any comments ?