### PR TITLE
Rollback tooltip change

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -323,9 +323,8 @@ class PointHTMLTooltip(PluginBase):
 
        obj.elements()
            .on("mouseover", function(d, i){
-			      if ($(obj.elements()[0][0]).css( "fill-opacity" ) > 0 || $(obj.elements()[0][0]).css( "stroke-opacity" ) > 0) {
                               tooltip.html(labels[i])
-                                     .style("visibility", "visible");} })
+                                     .style("visibility", "visible");})
            .on("mousemove", function(d, i){
                   tooltip
                     .style("top", d3.event.pageY + this.props.voffset + "px")


### PR DESCRIPTION
From commit https://github.com/jakevdp/mpld3/commit/9acbac966d7d4e9c5a95ba24665b8d243ba211b8
seem to rely on JQuery, which is not always available
